### PR TITLE
fix: surface team/station assignment errors in domjudge mode

### DIFF
--- a/backend/src/repository/team/http.rs
+++ b/backend/src/repository/team/http.rs
@@ -113,9 +113,17 @@ impl TeamRepository for HttpTeamRepo {
         if !new_ip.is_empty() {
             for u in &users {
                 if u.ip.as_deref() == Some(new_ip) && u.team_id.as_deref() != Some(team_id) {
-                    return Err(AppError::AlreadyExists(
-                        "ip already in use by another team".into(),
-                    ));
+                    tracing::warn!(
+                        team_id,
+                        ip = new_ip,
+                        conflicting_user = %u.id,
+                        conflicting_team = ?u.team_id,
+                        "refusing to assign ip: already in use by another team's user"
+                    );
+                    return Err(AppError::AlreadyExists(format!(
+                        "ip {new_ip} is already in use by another team (user {})",
+                        u.id
+                    )));
                 }
             }
         }
@@ -124,6 +132,19 @@ impl TeamRepository for HttpTeamRepo {
             .iter()
             .filter(|u| u.team_id.as_deref() == Some(team_id))
             .collect();
+
+        // The IP lives on the DOMjudge user, not the team. A team with no linked
+        // user has nowhere to store the IP, so assigning would silently no-op.
+        if team_users.is_empty() && !new_ip.is_empty() {
+            tracing::warn!(
+                team_id,
+                ip = new_ip,
+                "cannot assign ip: team has no DOMjudge user to bind it to"
+            );
+            return Err(AppError::FailedPrecondition(format!(
+                "team {team_id} has no DOMjudge user to bind the ip to"
+            )));
+        }
 
         let mut handles = Vec::new();
 

--- a/dashboard/src/components/AssignModal.tsx
+++ b/dashboard/src/components/AssignModal.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { adminClient } from "../lib/client";
+import { getErrorMessage } from "../lib/errors";
 import type { Station } from "@client/v1/admin/station_pb";
 import type { Team } from "@client/v1/admin/team_pb";
 
@@ -37,6 +38,10 @@ export function AssignModal({
       onClose();
     },
   });
+
+  const assignError = assignMutation.isError
+    ? getErrorMessage(assignMutation.error)
+    : null;
 
   const handleAssign = () => {
     if (!selectedValue) return;
@@ -84,6 +89,9 @@ export function AssignModal({
             <p className="text-sm text-gray-500 mt-2">
               All teams are already assigned
             </p>
+          )}
+          {assignError && (
+            <p className="text-sm text-danger-500 mt-2">{assignError}</p>
           )}
         </div>
 

--- a/dashboard/src/components/StationActionModal.tsx
+++ b/dashboard/src/components/StationActionModal.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { STATION_ACTIONS, type StationTarget } from "../lib/actions";
 import { useCommandStore } from "../context/command";
+import { getErrorMessage } from "../lib/errors";
 
 type StationActionProps = {
   stations: StationTarget[];
@@ -13,6 +14,7 @@ export function StationActinoModal({ stations, onClose }: StationActionProps) {
   const [fieldValues, setFieldValues] = useState<Record<string, string>>({});
   const [fieldErrors, setFieldErrors] = useState<Set<string>>(new Set());
   const [isPending, setIsPending] = useState(false);
+  const [actionError, setActionError] = useState<string | null>(null);
 
   const isSingle = stations.length === 1;
   const availableActions = STATION_ACTIONS.filter(
@@ -43,9 +45,15 @@ export function StationActinoModal({ stations, onClose }: StationActionProps) {
     }
 
     setIsPending(true);
-    await selectedAction.execute(stations, fieldValues, register);
-    setIsPending(false);
-    onClose();
+    setActionError(null);
+    try {
+      await selectedAction.execute(stations, fieldValues, register);
+      onClose();
+    } catch (err) {
+      setActionError(getErrorMessage(err));
+    } finally {
+      setIsPending(false);
+    }
   };
 
   return (
@@ -116,6 +124,10 @@ export function StationActinoModal({ stations, onClose }: StationActionProps) {
               );
             })}
           </>
+        )}
+
+        {actionError && (
+          <p className="text-sm text-danger-500 mt-4">{actionError}</p>
         )}
 
         <div className="flex justify-end gap-3 mt-6">

--- a/dashboard/src/lib/errors.ts
+++ b/dashboard/src/lib/errors.ts
@@ -1,0 +1,16 @@
+import { ConnectError } from "@connectrpc/connect";
+
+/**
+ * Extract a human-readable message from an error thrown by a gRPC-web call.
+ * ConnectError prefixes its `message` with the status code (e.g.
+ * "[already_exists] ..."); `rawMessage` gives just the server-provided text.
+ */
+export function getErrorMessage(error: unknown): string {
+  if (error instanceof ConnectError) {
+    return error.rawMessage || error.message;
+  }
+  if (error instanceof Error) {
+    return error.message;
+  }
+  return "Something went wrong";
+}

--- a/dashboard/src/pages/StationsPage.tsx
+++ b/dashboard/src/pages/StationsPage.tsx
@@ -1,6 +1,7 @@
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { Fragment, useState } from "react";
 import { adminClient } from "../lib/client";
+import { getErrorMessage } from "../lib/errors";
 import { AssignModal } from "../components/AssignModal";
 import { StationActinoModal } from "../components/StationActionModal";
 import { StationTerminal } from "../components/StationTerminal";
@@ -66,6 +67,10 @@ export function StationsPage() {
     },
   });
 
+  const unassignError = unassignMutation.isError
+    ? getErrorMessage(unassignMutation.error)
+    : null;
+
   const toggleTerminal = (ip: string) => {
     setExpandedIps((prev) => {
       const next = new Set(prev);
@@ -110,6 +115,11 @@ export function StationsPage() {
           </span>
         </div>
       </div>
+      {unassignError && (
+        <div className="mb-4 px-4 py-3 rounded-lg bg-danger-500/10 border border-danger-500/30 text-danger-500 text-sm">
+          {unassignError}
+        </div>
+      )}
       {isLoading ? (
         <div className="text-gray-400">Loading...</div>
       ) : stations.length === 0 ? (

--- a/dashboard/src/pages/TeamsPage.tsx
+++ b/dashboard/src/pages/TeamsPage.tsx
@@ -1,6 +1,7 @@
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { useState } from "react";
 import { adminClient } from "../lib/client";
+import { getErrorMessage } from "../lib/errors";
 import { AssignModal } from "../components/AssignModal";
 import type { Team } from "@client/v1/admin/team_pb";
 
@@ -27,6 +28,10 @@ export function TeamsPage() {
     },
   });
 
+  const unassignError = unassignMutation.isError
+    ? getErrorMessage(unassignMutation.error)
+    : null;
+
   const teams = data?.teams ?? [];
 
   const openAssignModal = (team: Team) => {
@@ -43,6 +48,11 @@ export function TeamsPage() {
           {teams.length} total
         </span>
       </div>
+      {unassignError && (
+        <div className="mb-4 px-4 py-3 rounded-lg bg-danger-500/10 border border-danger-500/30 text-danger-500 text-sm">
+          {unassignError}
+        </div>
+      )}
       {isLoading ? (
         <div className="text-gray-400">Loading...</div>
       ) : teams.length === 0 ? (


### PR DESCRIPTION
## Problem

In DOMjudge mode, assigning a team to a station could fail silently. The IP that binds a team to a station lives on the DOMjudge **user**, not the team, and two failure paths produced no visible feedback:

1. **Swallowed error (the reported bug).** When a stale user (e.g. the user of a team deleted in DOMjudge) still held a station IP, re-assigning that IP tripped the `already_exists` conflict guard in `HttpTeamRepo::set_ip`. The backend returned a proper gRPC error, but the dashboard mutations had **no `onError` handling**, so the user saw nothing and the team appeared "completely unusable."
2. **Silent no-op.** A team with no linked DOMjudge user has nowhere to store the IP. `set_ip` iterated zero users and returned `Ok(...)`, so the UI reported success while nothing changed.

## Changes

**Backend** (`backend/src/repository/team/http.rs`)
- Return `FailedPrecondition` when a team has no DOMjudge user to bind the IP to, instead of a silent no-op.
- Include the conflicting user id in the `AlreadyExists` message so the operator knows which user to fix in DOMjudge.
- Add `tracing::warn!` for both the conflict and no-user cases (nothing was logged before).

**Dashboard**
- New `lib/errors.ts` `getErrorMessage` helper that unwraps the gRPC error to the server-provided text.
- Surface assignment/unassign errors in `AssignModal`, `StationActionModal`, `TeamsPage`, and `StationsPage`. `StationActionModal` previously awaited `execute` with no try/catch and would hang on "Executing…" on error.

## Verification
- `cargo check` passes.
- Dashboard `typecheck` passes.
- `lint`: the only errors are pre-existing in files not touched by this change (`ContestPage.tsx`, `command.tsx`, `station.tsx`).

## Notes
- A global `QueryClient` `onError` handler was intentionally left out of scope (no toast system exists yet); the inline error displays follow the existing `ContestPage` pattern.

https://claude.ai/code/session_01SsA2Q59WJJ6FhqUAd7oXg3

---
_Generated by [Claude Code](https://claude.ai/code/session_01SsA2Q59WJJ6FhqUAd7oXg3)_